### PR TITLE
[Refactor] 카테고리 별 조회 API에서 ALL 제거

### DIFF
--- a/src/main/java/com/everytime/domain/post/service/PostService.java
+++ b/src/main/java/com/everytime/domain/post/service/PostService.java
@@ -23,6 +23,7 @@ public class PostService {
 
     public List<CategoryPostResponse> getAllPostsByCategory() {
         return Arrays.stream(Category.values())
+                .filter(category -> category != Category.ALL)
                 .map(category ->
                 {
                     List<Post> posts = postRepository.findTop4ByCategoryOrderByCreatedAtDesc(category);


### PR DESCRIPTION
## 📌 Related Issues
closes #27 

## 📄 Tasks
- [x] 카테고리 별 조회 API에서 'ALL'에 해당하는 값 응답에서 제거

## ⭐ PR Point (To Reviewer)
Category에 ALL(전체) enum을 추가하면서 게시글 목록 조회 시 ALL 카테고리까지 함께 응답에 포함되는 문제가 있어 이를 조회 대상에서 제외했습니다.

## 🔔 ETC

