### PR TITLE
[Refactor] QueryDSL 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/everytime/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/everytime/domain/post/mapper/PostMapper.java
@@ -1,0 +1,32 @@
+package com.everytime.domain.post.mapper;
+
+import com.everytime.domain.post.domain.Post;
+import com.everytime.domain.post.domain.enums.Category;
+import com.everytime.domain.post.dto.response.CategoryPostResponse;
+import com.everytime.domain.post.dto.response.PostSummaryResponse;
+import com.everytime.domain.post.dto.response.RealtimePostResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PostMapper {
+    public PostSummaryResponse toPostSummaryResponse(Post post) {
+        return PostSummaryResponse.from(post);
+    }
+
+    public List<PostSummaryResponse> toPostSummaryResponseList(List<Post> posts) {
+        return posts.stream()
+                .map(this::toPostSummaryResponse)
+                .toList();
+    }
+
+    public CategoryPostResponse toCategoryPostResponse(Category category, List<Post> posts) {
+        List<PostSummaryResponse> postDtos = toPostSummaryResponseList(posts);
+        return CategoryPostResponse.from(category, postDtos);
+    }
+
+    public RealtimePostResponse toRealtimePostResponse(Post post) {
+        return RealtimePostResponse.from(post);
+    }
+}

--- a/src/main/java/com/everytime/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/everytime/domain/post/repository/PostRepository.java
@@ -1,16 +1,9 @@
 package com.everytime.domain.post.repository;
 
 import com.everytime.domain.post.domain.Post;
-import com.everytime.domain.post.domain.enums.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findTop4ByCategoryOrderByCreatedAtDesc(Category category);
-    Optional<Post> findTopByOrderByLikeCountDescCreatedAtDesc();
-    List<Post> findTop4ByOrderByLikeCountDescCreatedAtDesc();
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 }

--- a/src/main/java/com/everytime/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/everytime/domain/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.everytime.domain.post.repository;
+
+import com.everytime.domain.post.domain.Post;
+import com.everytime.domain.post.domain.enums.Category;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostRepositoryCustom {
+    List<Post> findTop4ByCategoryOrderByCreatedAtDesc(Category category);
+
+    Optional<Post> findTopByOrderByLikeCountDescCreatedAtDesc();
+
+    List<Post> findTop4ByOrderByLikeCountDescCreatedAtDesc();
+}

--- a/src/main/java/com/everytime/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/everytime/domain/post/repository/PostRepositoryCustom.java
@@ -7,9 +7,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostRepositoryCustom {
-    List<Post> findTop4ByCategoryOrderByCreatedAtDesc(Category category);
+    List<Post> findLatest4PostsByCategory(Category category);
 
-    Optional<Post> findTopByOrderByLikeCountDescCreatedAtDesc();
+    Optional<Post> findTopRealtimePopularPost();
 
-    List<Post> findTop4ByOrderByLikeCountDescCreatedAtDesc();
+    List<Post> findTop4PopularPosts();
 }

--- a/src/main/java/com/everytime/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/everytime/domain/post/repository/PostRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.everytime.domain.post.repository;
+
+import com.everytime.domain.post.domain.Post;
+import com.everytime.domain.post.domain.QPost;
+import com.everytime.domain.post.domain.enums.Category;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private static final QPost post = QPost.post;
+
+    @Override
+    public List<Post> findTop4ByCategoryOrderByCreatedAtDesc(Category category) {
+        return jpaQueryFactory
+                .selectFrom(post)
+                .where(post.category.eq(category))
+                .orderBy(post.createdAt.desc())
+                .limit(4)
+                .fetch();
+    }
+
+    @Override
+    public Optional<Post> findTopByOrderByLikeCountDescCreatedAtDesc() {
+        Post result = jpaQueryFactory
+                .selectFrom(post)
+                .orderBy(post.likeCount.desc(), post.createdAt.desc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public List<Post> findTop4ByOrderByLikeCountDescCreatedAtDesc() {
+        return jpaQueryFactory
+                .selectFrom(post)
+                .orderBy(
+                        post.likeCount.desc(), post.createdAt.desc()
+                )
+                .limit(4)
+                .fetch();
+    }
+}

--- a/src/main/java/com/everytime/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/everytime/domain/post/repository/PostRepositoryImpl.java
@@ -16,7 +16,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     private static final QPost post = QPost.post;
 
     @Override
-    public List<Post> findTop4ByCategoryOrderByCreatedAtDesc(Category category) {
+    public List<Post> findLatest4PostsByCategory(Category category) {
         return jpaQueryFactory
                 .selectFrom(post)
                 .where(post.category.eq(category))
@@ -26,7 +26,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public Optional<Post> findTopByOrderByLikeCountDescCreatedAtDesc() {
+    public Optional<Post> findTopRealtimePopularPost() {
         Post result = jpaQueryFactory
                 .selectFrom(post)
                 .orderBy(post.likeCount.desc(), post.createdAt.desc())
@@ -37,7 +37,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public List<Post> findTop4ByOrderByLikeCountDescCreatedAtDesc() {
+    public List<Post> findTop4PopularPosts() {
         return jpaQueryFactory
                 .selectFrom(post)
                 .orderBy(

--- a/src/main/java/com/everytime/domain/post/service/PostService.java
+++ b/src/main/java/com/everytime/domain/post/service/PostService.java
@@ -5,6 +5,7 @@ import com.everytime.domain.post.domain.enums.Category;
 import com.everytime.domain.post.dto.response.CategoryPostResponse;
 import com.everytime.domain.post.dto.response.PostSummaryResponse;
 import com.everytime.domain.post.dto.response.RealtimePostResponse;
+import com.everytime.domain.post.mapper.PostMapper;
 import com.everytime.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +18,9 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PostService {
+
     private final PostRepository postRepository;
+    private final PostMapper postMapper;
 
     public List<CategoryPostResponse> getAllPostsByCategory() {
         return Arrays.stream(Category.values())
@@ -25,26 +28,19 @@ public class PostService {
                 .map(category ->
                 {
                     List<Post> posts = postRepository.findLatest4PostsByCategory(category);
-
-                    List<PostSummaryResponse> postDtos = posts.stream()
-                            .map(PostSummaryResponse::from)
-                            .toList();
-
-                    return CategoryPostResponse.from(category, postDtos);
+                    return postMapper.toCategoryPostResponse(category, posts);
                 })
                 .toList();
     }
 
     public RealtimePostResponse getRealtimePost() {
         return postRepository.findTopRealtimePopularPost()
-                .map(RealtimePostResponse::from)
+                .map(postMapper::toRealtimePostResponse)
                 .orElse(null);
     }
 
     public List<PostSummaryResponse> getHotPosts() {
         List<Post> posts = postRepository.findTop4PopularPosts();
-        return posts.stream()
-                .map(PostSummaryResponse::from)
-                .toList();
+        return postMapper.toPostSummaryResponseList(posts);
     }
 }

--- a/src/main/java/com/everytime/domain/post/service/PostService.java
+++ b/src/main/java/com/everytime/domain/post/service/PostService.java
@@ -6,8 +6,6 @@ import com.everytime.domain.post.dto.response.CategoryPostResponse;
 import com.everytime.domain.post.dto.response.PostSummaryResponse;
 import com.everytime.domain.post.dto.response.RealtimePostResponse;
 import com.everytime.domain.post.repository.PostRepository;
-import com.everytime.global.exception.CustomException;
-import com.everytime.global.exception.constant.PostErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +24,7 @@ public class PostService {
                 .filter(category -> category != Category.ALL)
                 .map(category ->
                 {
-                    List<Post> posts = postRepository.findTop4ByCategoryOrderByCreatedAtDesc(category);
+                    List<Post> posts = postRepository.findLatest4PostsByCategory(category);
 
                     List<PostSummaryResponse> postDtos = posts.stream()
                             .map(PostSummaryResponse::from)
@@ -38,13 +36,13 @@ public class PostService {
     }
 
     public RealtimePostResponse getRealtimePost() {
-        return postRepository.findTopByOrderByLikeCountDescCreatedAtDesc()
+        return postRepository.findTopRealtimePopularPost()
                 .map(RealtimePostResponse::from)
                 .orElse(null);
     }
 
     public List<PostSummaryResponse> getHotPosts() {
-        List<Post> posts = postRepository.findTop4ByOrderByLikeCountDescCreatedAtDesc();
+        List<Post> posts = postRepository.findTop4PopularPosts();
         return posts.stream()
                 .map(PostSummaryResponse::from)
                 .toList();

--- a/src/main/java/com/everytime/global/config/QueryDslConfig.java
+++ b/src/main/java/com/everytime/global/config/QueryDslConfig.java
@@ -1,0 +1,15 @@
+package com.everytime.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
## 📌 Related Issues
closes #51 

## 📄 Tasks
- [x] 게시글 조회 관련 쿼리를 JPA 메서드 이름 기반 쿼리에서 QueryDSL 기반으로 리팩토링
- build.gradle
   QueryDSL사용에 필요한 설정 파일을 추가했습니다.

- `QueryDslConfig`
   JPAQueryFactory Bean으로 등록하였습니다.

- `PostRepositoryImpl`
   QueryDSL을 사용해 메서드들을 구현하였습니다.

- `PostRepositoryCustom` 인터페이스 추가
    QueryDSL 도입 후, 기존 복잡했던 메서드명을 간단하게 수정하였습니다.

- [x] QueryDSL 도입에 따라 기존 메서드 명 수정
   `findLatest4PostsByCategory, findTopRealtimePopularPost, findTop4PopularPosts` 다음과 같이 메서드명을 수정하였습니다.


## ⭐ PR Point (To Reviewer)
**1. QueryDSL 도입 이유**
   기존에 어마무시!!! 했던 메서드 기반의 JPA 쿼리를 변경하기 위함이였는데요. 단순한 조회는 메서드 이름 기반 쿼리로 충분하지만 기존 구현된 메서드들은 여러 조건들로 인해 메서드명이 길어져 가독성도 떨어지고 유지보수 측면에도 어려움이 있었습니다. 
이에 기존 게시물 조회 관련 메서드에 도입하기로 결정하였습니다.

**2. Custom Repository 도입**
    Spring Data JPA Repository에 모든 메서드를 다 넣지 않고 도메인 별로 분리하여 유지보수성을 높이고자 하였습니다.


## 🔔 ETC
- 기존 JPA 메서드는 삭제하지 않고 QueryDSL로 대체했습니다.